### PR TITLE
Improve docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 # Use an official Rust nightly compiler as a parent image
 FROM archlinux/base
 
+RUN pacman -Sy --noconfirm rustup cmake gcc make intel-tbb; \
+  rustup install nightly; \
+  rustup default nightly;
+
 # Set the working directory to /app
 WORKDIR /app
 
 # Copy the current directory contents into the container at /app
 ADD . /app
-
-RUN pacman -Sy --noconfirm rustup cmake gcc make intel-tbb; \
-  rustup install nightly; \
-  rustup default nightly;
 
 # Build flow cutter
 RUN mkdir -p lib/InertialFlowCutter/build/ && cd lib/InertialFlowCutter/build/ && cmake -DCMAKE_BUILD_TYPE=Release -DUSE_KAHIP=OFF .. && make console && cd ../../..


### PR DESCRIPTION
For a successful docker build I had to add the following include in the `InertialFlowCutter` submodule:
```diff
diff --git a/src/list_graph.h b/src/list_graph.h
index 7443eb6..5889918 100644
--- a/src/list_graph.h
+++ b/src/list_graph.h
@@ -4,6 +4,7 @@
 #include "array_id_func.h"
 
 #include <tuple>
+#include <string>
 
 struct ListGraph{
        ListGraph()=default;
```
It did build on Ubuntu 20.04 (gcc 9.3.0) without this patch though.

But I still wasn't able to test, since I couldn't find data in the expected format. The closest thing from HERE I found was the RDF CSV data from https://developer.here.com/sample-data
Any pointers to test data?