### PR TITLE
Add feature impl_trait_in_assoc_type, because it got its own feature gate

### DIFF
--- a/engine/src/datastr/graph/floating_time_dependent/shortcut_graph.rs
+++ b/engine/src/datastr/graph/floating_time_dependent/shortcut_graph.rs
@@ -1044,7 +1044,7 @@ impl<'a> ReconstructionGraph<'a> {
             debug_assert!(self.ttf_available(shortcut_id, start, end));
         }
         for waiting in state.awaited_by.drain(..) {
-            let mut waiting_state = waiting.get_mut_from(incoming_reconstruction_states, outgoing_reconstruction_states);
+            let waiting_state = waiting.get_mut_from(incoming_reconstruction_states, outgoing_reconstruction_states);
             waiting_state.missing_deps -= 1;
             if waiting_state.missing_deps == 0 && !waiting_state.requested_times.is_empty() {
                 let new_el = ReconstructionQueueElement {
@@ -1751,7 +1751,7 @@ impl<'a> PartialProfileGraphWrapper<'a> {
             debug_assert!(self.ttf_available(shortcut_id, start, end));
         }
         for waiting in state.awaited_by.drain(..) {
-            let mut waiting_state = waiting.get_mut_from(incoming_reconstruction_states, outgoing_reconstruction_states);
+            let waiting_state = waiting.get_mut_from(incoming_reconstruction_states, outgoing_reconstruction_states);
             waiting_state.missing_deps -= 1;
             if waiting_state.missing_deps == 0 && !waiting_state.requested_times.is_empty() {
                 let (lower_node, upper_node) = if self.delegate(waiting) {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(array_windows)]
 #![feature(slice_group_by)]
 #![feature(type_alias_impl_trait)]
-#![feature(binary_heap_retain)]
+#![feature(impl_trait_in_assoc_type)]
 #![allow(clippy::collapsible_if)]
 #![allow(clippy::redundant_closure_call)]
 #![allow(clippy::debug_assert_with_mut_call)]


### PR DESCRIPTION
With new rust versions (e.g. rustc 1.71.0-nightly), the code doesn't compile anymore. Further information: https://github.com/rust-lang/rust/issues/63063

Additionally, removed unneccessary `mut`. 